### PR TITLE
Print correct logging origin

### DIFF
--- a/revel.go
+++ b/revel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	stdlog "log"
 	"runtime"
+	"runtime/debug"
 	"strings"
 
 	"github.com/revel/revel"
@@ -38,6 +39,9 @@ func (l *Logger) LevelPrint(lev mappers.Level, i ...interface{}) {
 	}
 	pf := fmt.Sprintf("%s:%d: ", shortenFile(file), line)
 	i = append([]interface{}{pf}, i...)
+	if t := trace(lev); t != "" {
+		i = append(i, "\n", t)
+	}
 	getRevelLevel(lev).Print(i...)
 }
 
@@ -49,6 +53,9 @@ func (l *Logger) LevelPrintf(lev mappers.Level, format string, i ...interface{})
 		line = 0
 	}
 	pf := fmt.Sprintf("%s:%d: ", shortenFile(file), line)
+	if t := trace(lev); t != "" {
+		i = append(i, "\n", t)
+	}
 	getRevelLevel(lev).Printf(pf+format, i...)
 }
 
@@ -61,6 +68,9 @@ func (l *Logger) LevelPrintln(lev mappers.Level, i ...interface{}) {
 	}
 	pf := fmt.Sprintf("%s:%d:", shortenFile(file), line)
 	i = append([]interface{}{pf}, i...)
+	if t := trace(lev); t != "" {
+		i = append(i, "\n", t)
+	}
 	getRevelLevel(lev).Println(i...)
 }
 
@@ -138,4 +148,34 @@ func shortenFile(file string) string {
 		}
 	}
 	return short
+}
+
+// stackTrace is a bit set for enabling stack traces.
+var stackTrace int
+
+// EnableTrace will enable stacktrace printing for the specified levels.
+// Should be set before usage.
+// Other levels are not affected.
+func EnableTrace(lev ...mappers.Level) {
+	for _, l := range lev {
+		stackTrace |= 1 << uint(l)
+	}
+}
+
+// DisableTrace will disable stacktrace printing for the specified levels.
+// Should be set before usage.
+// Other levels are not affected.
+func DisableTrace(lev ...mappers.Level) {
+	for _, l := range lev {
+		stackTrace &= ^(1 << uint(l))
+	}
+}
+
+// trace returns a stack trace if enabled for the level.
+// Otherwise an empty string is returned.
+func trace(lev mappers.Level) string {
+	if stackTrace&(1<<uint(lev)) == 0 {
+		return ""
+	}
+	return string(debug.Stack())
 }

--- a/revel.go
+++ b/revel.go
@@ -32,13 +32,7 @@ func NewLogger() loggers.Contextual {
 
 // LevelPrint is a Mapper method
 func (l *Logger) LevelPrint(lev mappers.Level, i ...interface{}) {
-	_, file, line, ok := runtime.Caller(3)
-	if !ok {
-		file = "???"
-		line = 0
-	}
-	pf := fmt.Sprintf("%s:%d: ", shortenFile(file), line)
-	i = append([]interface{}{pf}, i...)
+	i = append([]interface{}{caller(3)+" "}, i...)
 	if t := trace(lev); t != "" {
 		i = append(i, "\n", t)
 	}
@@ -47,27 +41,15 @@ func (l *Logger) LevelPrint(lev mappers.Level, i ...interface{}) {
 
 // LevelPrintf is a Mapper method
 func (l *Logger) LevelPrintf(lev mappers.Level, format string, i ...interface{}) {
-	_, file, line, ok := runtime.Caller(3)
-	if !ok {
-		file = "???"
-		line = 0
-	}
-	pf := fmt.Sprintf("%s:%d: ", shortenFile(file), line)
 	if t := trace(lev); t != "" {
 		i = append(i, "\n", t)
 	}
-	getRevelLevel(lev).Printf(pf+format, i...)
+	getRevelLevel(lev).Printf(caller(3)+" "+format, i...)
 }
 
 // LevelPrintln is a Mapper method
 func (l *Logger) LevelPrintln(lev mappers.Level, i ...interface{}) {
-	_, file, line, ok := runtime.Caller(3)
-	if !ok {
-		file = "???"
-		line = 0
-	}
-	pf := fmt.Sprintf("%s:%d:", shortenFile(file), line)
-	i = append([]interface{}{pf}, i...)
+	i = append([]interface{}{caller(3)}, i...)
 	if t := trace(lev); t != "" {
 		i = append(i, "\n", t)
 	}
@@ -178,4 +160,15 @@ func trace(lev mappers.Level) string {
 		return ""
 	}
 	return string(debug.Stack())
+}
+
+// caller returns the funtion call line at the specified depth
+// as "dir/file.go:n:
+func caller(depth int) string {
+	_, file, line, ok := runtime.Caller(depth+1)
+	if !ok {
+		file = "???"
+		line = 0
+	}
+	return fmt.Sprintf("%s:%d:", shortenFile(file), line)
 }

--- a/revel.go
+++ b/revel.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	stdlog "log"
 	"runtime"
-	"runtime/debug"
 	"strings"
 
 	"github.com/revel/revel"
@@ -32,27 +31,18 @@ func NewLogger() loggers.Contextual {
 
 // LevelPrint is a Mapper method
 func (l *Logger) LevelPrint(lev mappers.Level, i ...interface{}) {
-	i = append([]interface{}{caller(3)+" "}, i...)
-	if t := trace(lev); t != "" {
-		i = append(i, "\n", t)
-	}
+	i = append([]interface{}{caller(3) + " "}, i...)
 	getRevelLevel(lev).Print(i...)
 }
 
 // LevelPrintf is a Mapper method
 func (l *Logger) LevelPrintf(lev mappers.Level, format string, i ...interface{}) {
-	if t := trace(lev); t != "" {
-		i = append(i, "\n", t)
-	}
 	getRevelLevel(lev).Printf(caller(3)+" "+format, i...)
 }
 
 // LevelPrintln is a Mapper method
 func (l *Logger) LevelPrintln(lev mappers.Level, i ...interface{}) {
 	i = append([]interface{}{caller(3)}, i...)
-	if t := trace(lev); t != "" {
-		i = append(i, "\n", t)
-	}
 	getRevelLevel(lev).Println(i...)
 }
 
@@ -132,40 +122,10 @@ func shortenFile(file string) string {
 	return short
 }
 
-// stackTrace is a bit set for enabling stack traces.
-var stackTrace int
-
-// EnableTrace will enable stacktrace printing for the specified levels.
-// Should be set before usage.
-// Other levels are not affected.
-func EnableTrace(lev ...mappers.Level) {
-	for _, l := range lev {
-		stackTrace |= 1 << uint(l)
-	}
-}
-
-// DisableTrace will disable stacktrace printing for the specified levels.
-// Should be set before usage.
-// Other levels are not affected.
-func DisableTrace(lev ...mappers.Level) {
-	for _, l := range lev {
-		stackTrace &= ^(1 << uint(l))
-	}
-}
-
-// trace returns a stack trace if enabled for the level.
-// Otherwise an empty string is returned.
-func trace(lev mappers.Level) string {
-	if stackTrace&(1<<uint(lev)) == 0 {
-		return ""
-	}
-	return string(debug.Stack())
-}
-
 // caller returns the funtion call line at the specified depth
 // as "dir/file.go:n:
 func caller(depth int) string {
-	_, file, line, ok := runtime.Caller(depth+1)
+	_, file, line, ok := runtime.Caller(depth + 1)
 	if !ok {
 		file = "???"
 		line = 0

--- a/revel_test.go
+++ b/revel_test.go
@@ -2,8 +2,10 @@ package revel
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"regexp"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -107,8 +109,9 @@ func TestStackTrace(t *testing.T) {
 	EnableTrace(mappers.LevelError)
 	defer DisableTrace(mappers.LevelError)
 	l.Error("an error")
+	_, file, line, _ := runtime.Caller(0)
 
-	mustContain := "runtime/debug.Stack"
+	mustContain := fmt.Sprintf("%s:%d", file, line-1)
 	actual := b.String()
 	if ok := strings.Contains(actual, mustContain); !ok {
 		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)
@@ -120,8 +123,9 @@ func TestStackTraceF(t *testing.T) {
 	EnableTrace(mappers.LevelError)
 	defer DisableTrace(mappers.LevelError)
 	l.Errorf("an error: %s", "value")
+	_, file, line, _ := runtime.Caller(0)
 
-	mustContain := "runtime/debug.Stack"
+	mustContain := fmt.Sprintf("%s:%d", file, line-1)
 	actual := b.String()
 	if ok := strings.Contains(actual, mustContain); !ok {
 		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)
@@ -133,8 +137,9 @@ func TestStackTraceLn(t *testing.T) {
 	EnableTrace(mappers.LevelError)
 	defer DisableTrace(mappers.LevelError)
 	l.Errorln("an error")
+	_, file, line, _ := runtime.Caller(0)
 
-	mustContain := "runtime/debug.Stack"
+	mustContain := fmt.Sprintf("%s:%d", file, line-1)
 	actual := b.String()
 	if ok := strings.Contains(actual, mustContain); !ok {
 		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)

--- a/revel_test.go
+++ b/revel_test.go
@@ -2,16 +2,13 @@ package revel
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"regexp"
-	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/revel/revel"
 	"gopkg.in/birkirb/loggers.v1"
-	"gopkg.in/birkirb/loggers.v1/mappers"
 )
 
 func TestRevelInterface(t *testing.T) {
@@ -102,46 +99,4 @@ func newBufferedRevelLog() (loggers.Contextual, *bytes.Buffer) {
 	revel.WARN = log.New(bb, "WARN  ", log.Ldate|log.Ltime|log.Lshortfile)
 	revel.ERROR = log.New(bb, "ERROR ", log.Ldate|log.Ltime|log.Lshortfile)
 	return NewLogger(), bb
-}
-
-func TestStackTrace(t *testing.T) {
-	l, b := newBufferedRevelLog()
-	EnableTrace(mappers.LevelError)
-	defer DisableTrace(mappers.LevelError)
-	l.Error("an error")
-	_, file, line, _ := runtime.Caller(0)
-
-	mustContain := fmt.Sprintf("%s:%d", file, line-1)
-	actual := b.String()
-	if ok := strings.Contains(actual, mustContain); !ok {
-		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)
-	}
-}
-
-func TestStackTraceF(t *testing.T) {
-	l, b := newBufferedRevelLog()
-	EnableTrace(mappers.LevelError)
-	defer DisableTrace(mappers.LevelError)
-	l.Errorf("an error: %s", "value")
-	_, file, line, _ := runtime.Caller(0)
-
-	mustContain := fmt.Sprintf("%s:%d", file, line-1)
-	actual := b.String()
-	if ok := strings.Contains(actual, mustContain); !ok {
-		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)
-	}
-}
-
-func TestStackTraceLn(t *testing.T) {
-	l, b := newBufferedRevelLog()
-	EnableTrace(mappers.LevelError)
-	defer DisableTrace(mappers.LevelError)
-	l.Errorln("an error")
-	_, file, line, _ := runtime.Caller(0)
-
-	mustContain := fmt.Sprintf("%s:%d", file, line-1)
-	actual := b.String()
-	if ok := strings.Contains(actual, mustContain); !ok {
-		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)
-	}
 }

--- a/revel_test.go
+++ b/revel_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/revel/revel"
 	"gopkg.in/birkirb/loggers.v1"
+	"gopkg.in/birkirb/loggers.v1/mappers"
 )
 
 func TestRevelInterface(t *testing.T) {
@@ -99,4 +100,43 @@ func newBufferedRevelLog() (loggers.Contextual, *bytes.Buffer) {
 	revel.WARN = log.New(bb, "WARN  ", log.Ldate|log.Ltime|log.Lshortfile)
 	revel.ERROR = log.New(bb, "ERROR ", log.Ldate|log.Ltime|log.Lshortfile)
 	return NewLogger(), bb
+}
+
+func TestStackTrace(t *testing.T) {
+	l, b := newBufferedRevelLog()
+	EnableTrace(mappers.LevelError)
+	defer DisableTrace(mappers.LevelError)
+	l.Error("an error")
+
+	mustContain := "runtime/debug.Stack"
+	actual := b.String()
+	if ok := strings.Contains(actual, mustContain); !ok {
+		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)
+	}
+}
+
+func TestStackTraceF(t *testing.T) {
+	l, b := newBufferedRevelLog()
+	EnableTrace(mappers.LevelError)
+	defer DisableTrace(mappers.LevelError)
+	l.Errorf("an error: %s", "value")
+
+	mustContain := "runtime/debug.Stack"
+	actual := b.String()
+	if ok := strings.Contains(actual, mustContain); !ok {
+		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)
+	}
+}
+
+func TestStackTraceLn(t *testing.T) {
+	l, b := newBufferedRevelLog()
+	EnableTrace(mappers.LevelError)
+	defer DisableTrace(mappers.LevelError)
+	l.Errorln("an error")
+
+	mustContain := "runtime/debug.Stack"
+	actual := b.String()
+	if ok := strings.Contains(actual, mustContain); !ok {
+		t.Errorf("Log output mismatch %s (actual) != %s (expected)", actual, mustContain)
+	}
 }


### PR DESCRIPTION
Instead of printing `revel.go:26: ....` in front of all log messages this injects the correct calling position, along with the folder of the file.
