### PR TITLE
travis.yml: golang version changed from 1.4 to 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: go
-go: 1.4
+go: 1.9


### PR DESCRIPTION
travis.yml fails with following error: "import "math/bits": import path does not begin with hostname" because some part of https://gopkg.in/birkirb/loggers.v1 project depends on "math/bits" package:

![image](https://user-images.githubusercontent.com/5161479/42133791-2728a872-7d38-11e8-8df3-272de5f4e535.png)

which was released in Golang 1.9:

![image](https://user-images.githubusercontent.com/5161479/42133794-33ddd52e-7d38-11e8-8b83-40fbbb465024.png)

so, I fix this fail by changing `Go` version from 1.4 to 1.9 in `.travis.yml` file.